### PR TITLE
Add a step to new project setup to install plugins included in boilerplate.

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -59,6 +59,7 @@ Follow these instructions when you need to start a brand new CraftCMS from scrat
 1. MAMP users need to make sure and uncomment a line in the `.env` for `BACKUP_COMMAND`, `RESTORE_COMMAND`, and `DB_SOCKET`
 1. Run `$ ./craft setup` and follow the instructions, which will fill out the rest of the fields in your .env file and set up the database for first-time use.
 1. Run `$ npm install`, which will install all Node dependencies for this project.
+1. Access your control panel at `/admin` and login using the credentials you created during installation. Browse to Settings -> Plugins, and install each of the plugins listed.
 
 # Miscellaneous Information
 ### File/Directory Structure


### PR DESCRIPTION
Prior to this pull request, a successful setup from this boilerplate would cause errors on the front end because the templates included in the boilerplate depend on the included plugins, which are not installed during setup.  (They are composer installed, but not installed in the admin).

This may be better handled by providing instructions using the [`install\plugin`](https://craftcms.com/docs/3.x/console-commands.html#install-plugin) console command.   I chose not to include this in my pull request because I didn't want to require changes to the readme each time the boilerplate adds another plugin, and to my knowledge, there isn't a console command to install all plugins at once.